### PR TITLE
bugfix - table name index is uppercase

### DIFF
--- a/public_html/admin/model/localisation/language.php
+++ b/public_html/admin/model/localisation/language.php
@@ -405,7 +405,7 @@ class ModelLocalisationLanguage extends Model
             $this->db->table('orders'),
         );
         foreach ($lang_tables as $table) {
-            $table_name = $table['table_name'];
+            $table_name = $table['TABLE_NAME'];
             if(!$table_name && isset($table['TABLE_NAME'])){
                 $table_name = $table['TABLE_NAME'];
             }


### PR DESCRIPTION
The method _get_tables_info was returning null since the index name is TABLE_NAME and not table_name.
For this reason, some features were not working (like "Load missing language data").
The error thrown was:

```
2021-04-21 20:11:05 - database error: AbanteCart core v.1.2.16 SQL Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'WHERE language_id = 1' at line 3
Error No: 1064
SQL: SELECT COUNT(*) as cnt
FROM
WHERE language_id = 1
PHP call stack:
#0 /var/www/aixa/core/lib/db.php:100
#1 /var/www/aixa/core/engine/extensions.php:1176
#2 /var/www/aixa/core/engine/extensions.php:1127
#3 /var/www/aixa/core/lib/db.php:67
```